### PR TITLE
Fix missing package on build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+image: docker:latest
+
+services:
+  - docker:dind
+
+before_script:
+  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+
+build-master:
+  stage: build
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE" .
+    - docker push "$CI_REGISTRY_IMAGE"
+  only:
+    - master
+
+build:
+  stage: build
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update     \
     python          \
     rpm             \
     sudo            \
+    libarchive-dev  \
  && mkdir build     \
  && mkdir target    \
  && apt-get -y autoremove \


### PR DESCRIPTION
Hello,

This PR should fix container build issue due to a missing package in the docker file.

Feel free to pick out the gitlab-ci.yml file commit but it's standard and might help people build the docker image if they use Gitlab CI.

Fixes #2 