### PR TITLE
Support Singularity v2.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.3:
+  - Now supporting Singularity version 2.5.1 and set as default
+  - Image rebased from an Ubuntu 18.04 docker image
+
 1.0.2:
   - Added deboopstrap
   - Fixed 'Text File Busy' Build error

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER ARC-TS <arcts-dev@umich.edu>
 
 ARG BUILD_DATE
-ARG SINGULARITY_VERSION
+ARG SINGULARITY_VERSION=2.5.1
 ARG VCS_REF
 ARG VERSION
 
@@ -31,6 +31,9 @@ RUN apt-get update     \
     python          \
     rpm             \
     sudo            \
+    libarchive-dev  \
+    help2man        \
+    squashfs-tools  \
  && mkdir build     \
  && mkdir target    \
  && apt-get -y autoremove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER ARC-TS <arcts-dev@umich.edu>
 
 ARG BUILD_DATE

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$DOCKER_TAG" == 'latest' ]; then
-  s_version='2.2.1'
+  s_version='2.5.1'
 else
   s_version="$DOCKER_TAG"
 fi


### PR DESCRIPTION
This PR allows for support of Singularity 2.5.1 by adding necessary dependencies.

v2.5.1 is now the default.

Took the opportunity to rebase the image on Ubuntu 18.04 LTS and added squashfs tools to support this feature if needs be.